### PR TITLE
theme replacing should cut tons of irrelevant css

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -269,11 +269,17 @@
           '#1c8de0': 'selectOptionSelected',
           '#edf7ff': 'lightBackground'
         };
+        let colorOverrides = []; // only capture color overides
         Object.keys(colorMap).forEach(key => {
           const value = colorMap[key];
-          data = data.replace(new RegExp(key, 'ig'), value);
-        });
-        return data;
+          let repl = new RegExp(`(^|})([^{]+{[^{}]+)${key}\\b([^}]*)(?=})`, 'gi'); // find css color specifics
+          let nestRepl = new RegExp(key, 'ig'); // for greed matching before the 'key'
+          let v;
+          while ((v = repl.exec(data))) {
+            colorOverrides.push(v[2].replace(nestRepl, value) + value + v[3] + '}'); // '}' not captured in the regexp repl to reserve it as locator-boundary
+          }
+        })
+        return colorOverrides.join('');
       },
 
       getFile(url, isBlob = false) {


### PR DESCRIPTION
theme replacing should cut tons of irrelevant css
these codes have been tested OK
风格替换既然是颜色,那么应该削减大量无关的代码. 可以通过regexp
捕捉相关的,以上代码经过测试